### PR TITLE
Fix tokenizer_re, add progress dots, add continue on error

### DIFF
--- a/stellarisdashboard/config.py
+++ b/stellarisdashboard/config.py
@@ -185,6 +185,8 @@ class Config:
 
     log_to_file: bool = False
     debug_mode: bool = False
+    continue_on_parse_error: bool = True
+    show_progress_dots: bool = True
 
     tab_layout: Dict[str, List[str]] = None
 

--- a/stellarisdashboard/parsing/errors.py
+++ b/stellarisdashboard/parsing/errors.py
@@ -1,0 +1,2 @@
+class StellarisFileFormatError(Exception):
+    pass

--- a/stellarisdashboard/parsing/save_parser.py
+++ b/stellarisdashboard/parsing/save_parser.py
@@ -235,7 +235,9 @@ class BatchSavePathMonitor(SavePathMonitor):
                         try:
                             result = future.result()
                         except StellarisFileFormatError as e:
-                            logger.error(f"Skipping unparseable save file for {game_id}:")
+                            logger.error(
+                                f"Skipping unparseable save file for {game_id}:"
+                            )
                             logger.error(traceback.format_exc())
                             if config.CONFIG.continue_on_parse_error:
                                 continue
@@ -251,7 +253,7 @@ class BatchSavePathMonitor(SavePathMonitor):
                     yield save_file.parent.stem, parse_save(save_file)
                 except StellarisFileFormatError as e:
                     logger.error(f"Skipping unparseable save file {save_file}:")
-                    logger.error(traceback.format_exc())         
+                    logger.error(traceback.format_exc())
                     if config.CONFIG.continue_on_parse_error:
                         continue
                     else:
@@ -458,7 +460,7 @@ class SaveFileParser:
             else:
                 raise StellarisFileFormatError(f"Unexpected token: {next_token}")
         return result
-    
+
     def print_dot(self):
         """Prints a progress indicator every 100 tokens"""
         if self.should_print_dots:

--- a/stellarisdashboard/parsing/tokenizer_re.py
+++ b/stellarisdashboard/parsing/tokenizer_re.py
@@ -1,37 +1,33 @@
 import re
 
-WHITESPACE = re.compile(r"[\t\n ]*")
-EQ = re.compile(r"=")
-BR_OPEN = re.compile(r"{")
-BR_CLOSE = re.compile(r"}")
+from stellarisdashboard.parsing.errors import StellarisFileFormatError
+
+WHITESPACE = re.compile(r"[\t\n ]+")
+EQ_OR_BR = re.compile(r"[={}]")
 Q_STR = re.compile(r'"((\\")|[^"])*"')
-IDENTIFIER = re.compile(r"[0-9_]*[a-zA-Z_]+[a-zA-Z0-9_:]*")
+IDENTIFIER = re.compile(r"[a-zA-Z0-9_:.]+")
 FLOAT = re.compile(r"-?[0-9]+\.[0-9]*")
 INT = re.compile(r"-?[0-9]+")
 
 REG_EXES = [
-    BR_OPEN,
-    BR_CLOSE,
-    EQ,
+    EQ_OR_BR,
     Q_STR,
-    IDENTIFIER,
+    IDENTIFIER,  # Match the largest possible string first, the invoker of tokenizer will retest subsets INT and FLOAT for exact matches
     FLOAT,
     INT,
 ]
 
-
 def tokenizer(gamestate: str, debug=False):
+    global line_number
     N = len(gamestate)
     start_index = 0
     line_number = 1
     while start_index < N:
+        last_start_index = start_index
         m_ws = WHITESPACE.match(gamestate, pos=start_index)
         if m_ws:
             match_str = m_ws.group(0)
-            if debug:
-                for c in match_str:
-                    if c == "\n":
-                        line_number += 1
+            line_number += match_str.count("\n")
             start_index += len(match_str)
         for regex in REG_EXES:
             match = regex.match(gamestate, pos=start_index)
@@ -40,3 +36,6 @@ def tokenizer(gamestate: str, debug=False):
                 yield match_str, line_number
                 start_index += len(match_str)
                 break
+        if last_start_index == start_index:
+            end = start_index + 50 if start_index + 50 < N else N
+            raise StellarisFileFormatError(f'Stuck looking for next token at offset {start_index} [{gamestate[start_index:end]}]')

--- a/stellarisdashboard/parsing/tokenizer_re.py
+++ b/stellarisdashboard/parsing/tokenizer_re.py
@@ -17,6 +17,7 @@ REG_EXES = [
     INT,
 ]
 
+
 def tokenizer(gamestate: str, debug=False):
     global line_number
     N = len(gamestate)
@@ -38,4 +39,6 @@ def tokenizer(gamestate: str, debug=False):
                 break
         if last_start_index == start_index:
             end = start_index + 50 if start_index + 50 < N else N
-            raise StellarisFileFormatError(f'Stuck looking for next token at offset {start_index} [{gamestate[start_index:end]}]')
+            raise StellarisFileFormatError(
+                f"Stuck looking for next token at offset {start_index} [{gamestate[start_index:end]}]"
+            )


### PR DESCRIPTION
Tokenizer whitespace should not match empty string. IDENTIFIER can match almost anything text strings, numbers, text.number; all these things appear before an equals sign. Include an exit clause if the tokenizer gets stuck and is not incrementing.

Print progress dots when parsing each file. It gets ugly in multithreading.

Continue on any parsing error and move to / wait for the next file.