### PR TITLE
Add ability to export as animated webp

### DIFF
--- a/stellarisdashboard/dashboard_app/graph_ledger.py
+++ b/stellarisdashboard/dashboard_app/graph_ledger.py
@@ -7,6 +7,7 @@ import dash.exceptions
 import plotly.graph_objs as go
 from dash import Dash, callback_context, dcc, html, Input, Output
 from flask import render_template
+from PIL import features
 
 from stellarisdashboard import config, datamodel
 from stellarisdashboard.dashboard_app import (
@@ -270,6 +271,7 @@ def trigger_timeline_export(
     frame_time_ms = frame_time_ms or TIMELAPSE_DEFAULT_FRAME_TIME
 
     export_gif = "export_gif" in export_mode
+    export_webp = "export_webp" in export_mode
     export_frames = "export_frames" in export_mode
 
     changed_ids = [p["prop_id"].split(".")[0] for p in callback_context.triggered]
@@ -277,7 +279,7 @@ def trigger_timeline_export(
     if button_pressed:
         logger.info(f"Triggering timelapse export for {game_id}")
         logger.info(
-            f"{start_date=}, {end_date=}, {step_days=}, {frame_time_ms=}, {export_gif=}, {export_frames=}"
+            f"{start_date=}, {end_date=}, {step_days=}, {frame_time_ms=}, {export_gif=}, {export_webp=}, {export_frames=}"
         )
         try:
             tl_start_days = datamodel.date_to_days(start_date)
@@ -301,6 +303,7 @@ def trigger_timeline_export(
             step_days=step_days,
             tl_duration=frame_time_ms,
             export_gif=export_gif,
+            export_webp=export_webp,
             export_frames=export_frames,
         )
 
@@ -787,6 +790,16 @@ def get_layout():
                                 "value": "export_gif",
                             },
                             {
+                                "label": "Export webp (smaller than gif, slow)",
+                                "title": (
+                                    "Export the timelapse as a single (large) webp file. "
+                                    "Should end up smaller than the equivalent gif. "
+                                    "Requires the system WebP library to support animated WebP."
+                                ),
+                                "value": "export_webp",
+                                "disabled": not features.check("webp_anim"),
+                            },
+                            {
                                 "label": "Export frames",
                                 "title": (
                                     "Export the individual frames of the timelapse in png format. "
@@ -795,7 +808,7 @@ def get_layout():
                                 "value": "export_frames",
                             },
                         ],
-                        value=["export_gif", "export_frames"],
+                        value=["export_gif", ],
                         labelStyle=dict(color=TEXT_COLOR),
                         style={"text-align": "center"},
                     ),


### PR DESCRIPTION
Adds WebP animated export support. In my test of a tiny galaxy in 2350, the webp was 22% of the size of the gif:

```
-rw-rw-r-- 1 c c 16159972 Nov 21 19:48 mpseriousempirename_1645140075-2022-11-21-194604.gif
-rw-rw-r-- 1 c c  3572372 Nov 21 19:51 mpseriousempirename_1645140075-2022-11-21-194604.webp
```
The webp looks like this: https://freeimage.host/i/HJQpqwN

WebP is a "new" image format, where animated WebPs are [already well supported](https://developers.google.com/speed/webp/faq#which_web_browsers_natively_support_webp) by the browsers ("only" since 2020 for Edge); and since 2016 for libwebp and 2017 for Pillow, although I put a feature check on the checkbox, just in case.

The export is slower than gif. The [tuning options](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp-saving) are explicitly set here to the defaults, for ease of changing if we want to. I added some logging to allow timing, example:

```
MainProcess - 2022-11-21 19:46:04,604 - stellarisdashboard.dashboard_app.timelapse_exporter - INFO - Exporting animated image
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 458/458 [02:16<00:00,  3.34it/s]
MainProcess - 2022-11-21 19:48:21,587 - stellarisdashboard.dashboard_app.timelapse_exporter - INFO - Exporting timelapse gif to /home/c/stellaris-dashboard/output/galaxy-timelapse/mpseriousempirename_1645140075-2022-11-21-194604.gif
MainProcess - 2022-11-21 19:48:57,266 - stellarisdashboard.dashboard_app.timelapse_exporter - INFO - Exporting timelapse webp to /home/c/stellaris-dashboard/output/galaxy-timelapse/mpseriousempirename_1645140075-2022-11-21-194604.webp
MainProcess - 2022-11-21 19:51:16,693 - stellarisdashboard.dashboard_app.timelapse_exporter - INFO - Exports complete.
```