### PR TITLE
Skip parsing a war when a participant country is unknown. Fixes #74

### DIFF
--- a/stellarisdashboard/parsing/timeline.py
+++ b/stellarisdashboard/parsing/timeline.py
@@ -3002,7 +3002,7 @@ class WarProcessor(AbstractGamestateDataProcessor):
                 logger.warning(
                     f"{self._basic_info.logger_str}     Could not find country matching war participant {war_party_info}"
                 )
-                # continue
+                continue
 
             call_type = war_party_info.get("call_type", "unknown")
             caller = None


### PR DESCRIPTION
This fix prevents the crash in #74. 

The line was commented out in #65, but as reported, this lets a None continue on until the crash on (currently) line 3038: https://github.com/eliasdoehne/stellaris-dashboard/blob/7542674b4374050aa058241ad69d4aa50c5af773/stellarisdashboard/parsing/timeline.py#L3038

Now only the (already existing) warning is emitted, and parsing continues.

```
MainProcess - 2022-11-23 13:32:48,590 - stellarisdashboard.parsing.timeline - WARNING - test_9673941 2256.04.06     Could not find country matching war participant {'call_type': 'primary', 'country': 12, 'caller': 4294967295, 'fleets_gone_mia': 0}
```