### PR TITLE
Add option for production WSGI server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ SQLAlchemy==1.4.41
 tenacity==8.1.0
 tqdm==4.64.1
 Werkzeug==2.2.2
+waitress==2.1.2

--- a/stellarisdashboard/config.py
+++ b/stellarisdashboard/config.py
@@ -198,6 +198,7 @@ DEFAULT_SETTINGS = dict(
     tab_layout=DEFAULT_TAB_LAYOUT,
     market_resources=DEFAULT_MARKET_RESOURCES,
     market_fee=DEFAULT_MARKET_FEE,
+    production=False,
 )
 
 
@@ -237,6 +238,8 @@ class Config:
     market_resources: List[Dict[str, Any]] = None
     market_fee: List[Dict[str, float]] = None
 
+    production: bool = False
+
     PATH_KEYS = {
         "base_output_path",
         "save_file_path",
@@ -250,6 +253,7 @@ class Config:
         "show_all_country_types",
         "log_to_file",
         "include_id_in_names",
+        "production",
     }
     INT_KEYS = {
         "port",

--- a/stellarisdashboard/dashboard_app/graph_ledger.py
+++ b/stellarisdashboard/dashboard_app/graph_ledger.py
@@ -704,7 +704,11 @@ def start_dash_app(host, port):
     timeline_app.css.config.serve_locally = True
     timeline_app.scripts.config.serve_locally = True
     timeline_app.layout = get_layout()
-    timeline_app.run_server(host=host, port=port)
+    if config.CONFIG.production == True:
+        from waitress import serve
+        serve(timeline_app.server, host=host, port=port)
+    else:
+        timeline_app.run_server(host=host, port=port)
 
 
 def get_layout():


### PR DESCRIPTION
Dash prints a red Flask warning every startup:

```
MainProcess - 2022-12-05 15:11:56,080 - werkzeug - INFO - WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
```

This PR adds a new flag `production` that uses waitress instead of Dash to serve the WSGI app. (I picked waitress because out of the [Flask suggestions](https://flask.palletsprojects.com/en/2.2.x/deploying/) it was the first one I got working and it was a small change).

In my testing, nothing looked broken, and waitress is faster, mostly noticeable on first load (or with browser cache disabled)

Waitress:
 
![image](https://user-images.githubusercontent.com/2653277/205736390-ae101552-af24-4b08-b768-1bf3fabea26b.png)

Flask:

![image](https://user-images.githubusercontent.com/2653277/205736722-67466350-1756-432a-8a7c-d98f561028df.png)

