### PR TITLE
Add Cython language level to tokenizer.pyx

### DIFF
--- a/stellarisdashboard/parsing/cython_ext/tokenizer.pyx
+++ b/stellarisdashboard/parsing/cython_ext/tokenizer.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from cpython cimport bool
 
 def tokenizer(str gamestate, bool debug=False):


### PR DESCRIPTION
I've been running the dashboard on Python 3.10 / Cython==0.29.32. The following error happens then, and also with Python 3.8 (same Cython version -- not sure when the FutureWarning was introduced).  Whenever tokenizer.pyx gets compiled (manually: `python setup.py build_ext --inplace`), this warning is printed in red:

```
/home/stellaris/.local/lib/python3.10/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/stellaris/stellaris-dashboard/stellarisdashboard/parsing/cython_ext/tokenizer.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
```

Adding the language level to the top of the file silences it. And since Python 3 is required for this project, it seems like a good idea to use 3 here anyway.

As a bonus, in my test (2 runs each), language_level=3 parses one of my late-game save folders 10 seconds faster than the default language_level=2 (2m45s vs 2m55s)