### PR TITLE
Update SciPy to 1.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ plotly==5.10.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
 PyYAML==6.0
-scipy==1.9.1
+scipy==1.9.3
 six==1.16.0
 SQLAlchemy==1.4.41
 tenacity==8.1.0


### PR DESCRIPTION
I've been wanting to try the dashboard on Python 3.11 and Alpine Linux (musl), and I cannot get scipy 1.9.1 to compile to a working state if there is no wheel present for it on pypi, which is the case for certain versions.  But 1.9.3 works.

SciPy releases https://github.com/scipy/scipy/releases