### PR TITLE
Handle new 3.6 templates: %ADJECTIVE%, %ADJ%, and %LEADER_2%. Fixes #90

### DIFF
--- a/stellarisdashboard/game_info.py
+++ b/stellarisdashboard/game_info.py
@@ -33,6 +33,8 @@ class NameRenderer:
         # Alternate format with no template (meant to be concatenated?). Incomplete solution.
 #        if "%ADJ%" not in self.name_mapping:
 #          self.name_mapping["%ADJ%"] = "$1$"
+        if "%LEADER_2%" not in self.name_mapping:
+          self.name_mapping["%LEADER_2%"] = "$1$ $2$"
 
     def render_from_json(self, name_json: str):
         try:

--- a/stellarisdashboard/game_info.py
+++ b/stellarisdashboard/game_info.py
@@ -27,6 +27,12 @@ class NameRenderer:
                         self.name_mapping[key.strip().rstrip(":0")] = val.strip()
                     except Exception:
                         pass
+        # Add missing format that is similar to but not the same as adj_format in practice
+        if "%ADJECTIVE%" not in self.name_mapping:
+          self.name_mapping["%ADJECTIVE%"] = "$adjective$ $1$"
+        # Alternate format with no template (meant to be concatenated?). Incomplete solution.
+#        if "%ADJ%" not in self.name_mapping:
+#          self.name_mapping["%ADJ%"] = "$1$"
 
     def render_from_json(self, name_json: str):
         try:
@@ -52,6 +58,11 @@ class NameRenderer:
             return key
 
         render_template = self.name_mapping.get(key, key)
+        # The %ADJ% template is odd. See GitHub #90
+        if render_template == "%ADJ%":
+            render_template = "$1$"
+            if "variables" in name_dict and "value" in name_dict["variables"][0] and "key" in name_dict["variables"][0]["value"]:
+                name_dict["variables"][0]["value"]["key"] += " $1$"
 
         substitution_values = []
         if "value" in name_dict:
@@ -69,6 +80,7 @@ class NameRenderer:
                 ("<", ">"),
                 ("[", "]"),
                 ("$", "$"),
+                ("%", "%"),
             ]:
                 render_template = render_template.replace(
                     f"{lparen}{subst_key}{rparen}", subst_value

--- a/stellarisdashboard/game_info.py
+++ b/stellarisdashboard/game_info.py
@@ -33,6 +33,8 @@ class NameRenderer:
         # Alternate format with no template (meant to be concatenated?). Incomplete solution.
 #        if "%ADJ%" not in self.name_mapping:
 #          self.name_mapping["%ADJ%"] = "$1$"
+        if "%LEADER_1%" not in self.name_mapping:
+          self.name_mapping["%LEADER_1%"] = "$1$ $2$"
         if "%LEADER_2%" not in self.name_mapping:
           self.name_mapping["%LEADER_2%"] = "$1$ $2$"
 

--- a/stellarisdashboard/parsing/timeline.py
+++ b/stellarisdashboard/parsing/timeline.py
@@ -1152,10 +1152,14 @@ class LeaderProcessor(AbstractGamestateDataProcessor):
         return leader
 
     def get_leader_name(self, leader_dict):
+        name_dict = leader_dict.get("name", {})
+        # Look for "first_name" then "full_names" (3.6+)
         first_name = dump_name(
-            leader_dict.get("name", {}).get("first_name", "Unknown Leader")
+            name_dict.get("first_name",
+                          name_dict.get("full_names", "Unknown Leader")
+            )
         )
-        last_name = dump_name(leader_dict.get("name", {}).get("second_name", ""))
+        last_name = dump_name(name_dict.get("second_name", ""))
         return first_name, last_name
 
     def _update_leader_attributes(self, leader: datamodel.Leader, leader_dict):

--- a/test/names_test.py
+++ b/test/names_test.py
@@ -180,6 +180,17 @@ def test_name_rendering_with_game_files(test_case: NameTestcase):
         ),
         NameTestcase(
             dict(
+                key="%LEADER_2%",
+                variables=[
+                    {"key": "1", "value": {"key": "Golveso"}},
+                    {"key": "2", "value": {"key": "Selvayn"}},
+                ],
+            ),
+            expected="Golveso Selvayn",
+            description="%LEADER_2% template",
+        ),
+        NameTestcase(
+            dict(
                 key="%ADJECTIVE%",
                 variables=[
                     {"key": "adjective", "value": {"key": "Nexitron"}},

--- a/test/names_test.py
+++ b/test/names_test.py
@@ -178,6 +178,48 @@ def test_name_rendering_with_game_files(test_case: NameTestcase):
             expected="Combined SPEC_DOESNOTEXIST Suns",
             description="empire, template with variables, nested does not exist",
         ),
+        NameTestcase(
+            dict(
+                key="%ADJECTIVE%",
+                variables=[
+                    {"key": "adjective", "value": {"key": "Nexitron"}},
+                    {"key": "1", "value": {"key": "Awareness"}},
+                ],
+            ),
+            expected="Nexitron Awareness",
+            description="%ADJECTIVE% template",
+        ),
+        NameTestcase(
+            dict(
+                key="%ADJ%",
+                variables=[
+                    {"key": "1", "value": {"key": "Allied", "variables": [
+                        {"key": "1", "value": {"key": "%ADJECTIVE%", "variables": [
+                            {"key": "adjective", "value": {"key": "Jing"}},
+                            {"key": "1", "value": {"key": "Systems"}}
+                        ]}}
+                    ]}}
+                ]
+            ),
+            expected="Allied Jing Systems",
+            description="%ADJ% test",
+        ),
+        NameTestcase(
+            dict(
+                key="%ADJECTIVE%",
+                variables=[
+                    {"key": "adjective", "value": {"key": "Quetzan"}},
+                    {"key": "1", "value": {"key": "%ADJ%", "variables": [
+                        {"key": "1", "value": {"key": "Consolidated", "variables": [
+                            {"key": "1", "value": {"key": "Worlds"}}
+                        ]}}
+                    ]}}
+                ]
+
+            ),
+            expected="Quetzan Consolidated Worlds",
+            description="Nested %ADJECTIVE% and %ADJ% test",
+        ),
     ],
     ids=lambda tc: tc.description,
 )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2653277/208529987-d5da54e3-4a6e-4f6e-8479-9241037c6576.png)

The `%ADJECTIVE%` template is easy enough to add, but `%ADJ%` doesn't work the same way (see #90 for an example). In this solution I special-cased `%ADJ%` by (1) changing `%ADJ%` to `$1$` **and** (2) appending to the template (key) a few levels down to allow the recursive template replacement to properly replace and keep all parts of the name.

Also adds test cases.