### PR TITLE
Change empire name in exported timelapse to medium white on black for readability

### DIFF
--- a/stellarisdashboard/dashboard_app/timelapse_exporter.py
+++ b/stellarisdashboard/dashboard_app/timelapse_exporter.py
@@ -6,6 +6,7 @@ from typing import Tuple, Optional
 
 import matplotlib
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as path_effects
 import networkx as nx
 import numpy as np
 import tqdm
@@ -216,9 +217,10 @@ class TimelapseExporter:
                     x,
                     position,
                     country,
-                    color=avg_pos["color"],
-                    size="x-small",
+                    color="white",
+                    size="medium",
                     ha="center",
+                    path_effects=[path_effects.withStroke(linewidth=2, foreground="black")],
                 )
 
         for x_values, y_values in self.galaxy_map_data.get_country_border_ridges(


### PR DESCRIPTION
I find the current text color (almost the same as the empire fill color) to be hard to read.  This takes a small part of #80 that isn't related to empire colors. It changes the empire name text on the timelapse export to a medium-size white with black outline. I found that the most readable, although I'm slightly sad to not be using the empire color in the text.

Image: https://i.imgur.com/1JIGcej.gif (wait til 2246)

Here is a comparison of several options considered: https://imgur.com/a/shYAEMS