### PR TITLE
Read more keys from localisation files

### DIFF
--- a/test/localization_test_files/english/empire_formats_l_english.yml
+++ b/test/localization_test_files/english/empire_formats_l_english.yml
@@ -1,2 +1,3 @@
 l_english:
  format.gen_imp.1:0 "<generic_aut_desc> [This.GetSpeciesName] <generic_states>"
+ NAME_Ketling_Multitude:1 "Ketling Star Pack"

--- a/test/names_test.py
+++ b/test/names_test.py
@@ -202,6 +202,17 @@ def test_name_rendering_with_game_files(test_case: NameTestcase):
         ),
         NameTestcase(
             dict(
+                key="%ADJECTIVE%",
+                variables=[
+                    {"key": "adjective", "value": {"key": "NAME_Ketling_Multitude"}},
+                    {"key": "1", "value": {"key": "Nation"}},
+                ],
+            ),
+            expected="Ketling Star Pack Nation",
+            description=":1 template",
+        ),
+        NameTestcase(
+            dict(
                 key="%ADJ%",
                 variables=[
                     {"key": "1", "value": {"key": "Allied", "variables": [


### PR DESCRIPTION
This fixes several missing localisation key:value pairs.

Before:

![image](https://user-images.githubusercontent.com/2653277/215619642-d8cd6fd8-f6bc-40d0-81f1-ebfcfb787266.png)

After:

![image](https://user-images.githubusercontent.com/2653277/215619851-21f7c2ff-0b84-4809-951d-431c083f5bdf.png)


The code previously assumed that the number after the colon would always be `0`, but it turns out that isn't true, and that we shouldn't care about it [1][2].  This PR picks up everything in the localisation files.

Example from `localisation/english/distant_stars_l_english.yml` (3.6.1):

```
 NAME_Ketling_Multitude:1 "Ketling Star Pack"
```

Also adds a test for it.

Unfortunately I don't have a real save from when this happened in my game, but, I did fake one by replacing `"NAME_Ketling"` with `"NAME_Ketling_Multitude"` in a save file and it worked.

[1] https://stellaris.paradoxwikis.com/Localisation_modding#Localisation_Keys
[2] https://twitter.com/Martin_Anward/status/1039175213773144066