### PR TITLE
Fix warnings about invalid escape sequences

### DIFF
--- a/stellarisdashboard/config.py
+++ b/stellarisdashboard/config.py
@@ -456,7 +456,7 @@ def _get_mod_data_dir(mod_descriptor_path: pathlib.Path):
     try:
         with open(mod_descriptor_path, "r") as f:
             for line in f:
-                match = re.match('^\s*path\s*=\s*"(.*)"\s*$', line)
+                match = re.match(r'^\s*path\s*=\s*"(.*)"\s*$', line)
                 if match:
                     return pathlib.Path(match.group(1))
     except Exception as e:
@@ -468,7 +468,7 @@ def _get_mod_data_dir(mod_descriptor_path: pathlib.Path):
 def _localization_file_matches_language(file_path: pathlib.Path, language: str):
     with open(file_path, "r") as f:
         first_line = f.readline()
-        match = re.match(f"^\ufeff\s*{language}\s*:\s*$", first_line)
+        match = re.match(rf"^\ufeff\s*{language}\s*:\s*$", first_line)
         return match is not None
 
 

--- a/stellarisdashboard/dashboard_app/visualization_data.py
+++ b/stellarisdashboard/dashboard_app/visualization_data.py
@@ -1775,7 +1775,7 @@ class CountryColors:
     @staticmethod
     def _parse_map_colors(path: pathlib.Path):
         with open(path, "r") as f:
-            prepared_str = re.sub("#[^\n]*", "", f.read())  # strip out comments
+            prepared_str = re.sub(r"#[^\n]*", "", f.read())  # strip out comments
             data = rust_parser.parse_save_from_string(prepared_str)
 
             colors = data.get("colors", {})

--- a/stellarisdashboard/game_info.py
+++ b/stellarisdashboard/game_info.py
@@ -191,7 +191,7 @@ class NameRenderer:
             if match == "ORD":
                 continue
             resolved = lookup_key(match)
-            render_template = re.sub(f"\${match}\$", resolved, render_template)
+            render_template = re.sub(rf"\${match}\$", resolved, render_template)
 
         return render_template
 


### PR DESCRIPTION
I received the following warnings on Python 3.10.12.  (Python 3.12 changes them to SyntaxWarning).  This PR changes multiple strings fed to `re` in to raw strings (and yes, [f and r can be combined like that](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)).

```
stellarisdashboard/config.py:459
  /home/.../stellaris-dashboard/stellarisdashboard/config.py:459: DeprecationWarning: invalid escape sequence '\s'
    match = re.match('^\s*path\s*=\s*"(.*)"\s*$', line)

stellarisdashboard/config.py:471
stellarisdashboard/config.py:471
  /home/.../stellaris-dashboard/stellarisdashboard/config.py:471: DeprecationWarning: invalid escape sequence '\s'
    match = re.match(f"^\ufeff\s*{language}\s*:\s*$", first_line)

test/parser_test.py::test_real_save
test/parser_test.py::test_real_save
  /home/.../stellaris-dashboard/stellarisdashboard/game_info.py:194: DeprecationWarning: invalid escape sequence '\$'
    render_template = re.sub(f"\${match}\$", resolved, render_template)
```