### PR TITLE
Expand parse test coverage by reading all countries

### DIFF
--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -30,6 +30,7 @@ def test_real_save(tmp_path):
     from stellarisdashboard import cli, config
     from pathlib import Path
     config.CONFIG.debug_mode = True
+    config.CONFIG.read_all_countries = True
     config.CONFIG.base_output_path = tmp_path
     cli.f_parse_saves(save_path="test/saves")
     assert len(list(tmp_path.glob('**/*.db'))) > 0, f"When parsing saves, no output .db files were produced (output folder: {tmp_path})"


### PR DESCRIPTION
Enable read_all_countries for the real save parsing test. No errors found this time, but expanded coverage is a good thing.

Adds 5-15s to the test portion of the build.

[Master action run](https://github.com/chennin/stellaris-dashboard/actions/runs/9227411136)

[This branch action run](https://github.com/chennin/stellaris-dashboard/actions/runs/9227427515)