### PR TITLE
Fix escaped backslash at end of quoted string erroneously escapes the final quote

### DIFF
--- a/stellarisdashboard/parsing/rust_parser/src/parser.rs
+++ b/stellarisdashboard/parsing/rust_parser/src/parser.rs
@@ -586,6 +586,14 @@ mod tests {
     }
 
     #[test]
+    fn test_escaped_backslash() {
+        // from a bug report for a save that failed to parse
+        // narrowed down to mishandled escaped backslash at end of string
+        let test_input = "prefix=\"GATE \\\\\"";
+        parse_file(test_input).expect("Should parse");
+    }
+
+    #[test]
     fn test_skipped_key_in_mapping() {
         assert_eq!(
             parse_map_key_value_pair("key=other_key=value_1").expect("asdf"),

--- a/stellarisdashboard/parsing/rust_parser/src/parser.rs
+++ b/stellarisdashboard/parsing/rust_parser/src/parser.rs
@@ -247,7 +247,7 @@ fn parse_float(input: &str) -> IResult<&str, f64> {
 fn parse_str(input: &str) -> IResult<&str, &str> {
     preceded(
         multispace0,
-        delimited(tag("\""), escaped(none_of("\"\\"), '\\', one_of("\"")), tag("\"")),
+        delimited(tag("\""), escaped(none_of("\"\\"), '\\', one_of("\"\\")), tag("\"")),
     )(input)
 }
 


### PR DESCRIPTION
Not much to say besides the title. We simply needed to add `\` to the potentially escaped characters.