### PR TITLE
Fix countryless leader died event

### DIFF
--- a/mod/stellaris_dashboard/descriptor.mod
+++ b/mod/stellaris_dashboard/descriptor.mod
@@ -1,5 +1,5 @@
 name="Stellaris Dashboard"
-version="v6.5.1"
+version="v6.5.2"
 tags={
 	"Utilities"
 	"Gameplay"

--- a/mod/stellaris_dashboard/interface/main_bottom.gui
+++ b/mod/stellaris_dashboard/interface/main_bottom.gui
@@ -476,7 +476,7 @@ guiTypes = {
 				pdx_tooltip = "STELLARIS_DASHBOARD_TOOLTIP"
 				pdx_tooltip_anchor_offset = { x= 0 y = @tt_offset_y }
 				pdx_tooltip_anchor_orientation = lower_left
-				web_link="http://127.0.0.1:28053/checkversion/v6.5.1"
+				web_link="http://127.0.0.1:28053/checkversion/v6.5.2"
 			}
 
 			iconType = {

--- a/stellarisdashboard/dashboard_app/utils.py
+++ b/stellarisdashboard/dashboard_app/utils.py
@@ -7,7 +7,7 @@ from stellarisdashboard import datamodel
 
 logger = logging.getLogger(__name__)
 
-VERSION = "v6.5.1"
+VERSION = "v6.5.2"
 
 
 def parse_version(version: str):

--- a/stellarisdashboard/parsing/timeline.py
+++ b/stellarisdashboard/parsing/timeline.py
@@ -1128,7 +1128,7 @@ class LeaderProcessor(AbstractGamestateDataProcessor):
                 country = self._countries_by_ingame_id.get(leader_dict.get("country"))
                 self._update_leader_attributes(country=country, leader=leader, leader_dict=leader_dict)
             if not leader.is_active:
-                country_data = leader.country.get_most_recent_data()
+                country_data = leader.country.get_most_recent_data() if country is not None else None
                 self._session.add(
                     datamodel.HistoricalEvent(
                         event_type=datamodel.HistoricalEventType.leader_died,

--- a/stellarisdashboard/parsing/timeline.py
+++ b/stellarisdashboard/parsing/timeline.py
@@ -1128,7 +1128,7 @@ class LeaderProcessor(AbstractGamestateDataProcessor):
                 country = self._countries_by_ingame_id.get(leader_dict.get("country"))
                 self._update_leader_attributes(country=country, leader=leader, leader_dict=leader_dict)
             if not leader.is_active:
-                country_data = leader.country.get_most_recent_data() if country is not None else None
+                country_data = leader.country.get_most_recent_data() if leader.country is not None else None
                 self._session.add(
                     datamodel.HistoricalEvent(
                         event_type=datamodel.HistoricalEventType.leader_died,


### PR DESCRIPTION
Rarely, leaders do not have countries
The leader died event wasn't accounting for that when getting the country_data