### PR TITLE
Fix save parse fails on valueless key

### DIFF
--- a/stellarisdashboard/parsing/save_parser.py
+++ b/stellarisdashboard/parsing/save_parser.py
@@ -28,6 +28,9 @@ from stellarisdashboard import config
 
 logger = logging.getLogger(__name__)
 
+# the default recursion limit was not high enough for pickling some parsed saves (pickle used by futures)
+if sys.getrecursionlimit() < 2000:
+    sys.setrecursionlimit(2000)
 
 class StellarisFileFormatError(Exception):
     pass

--- a/test/parser_test_cases.py
+++ b/test/parser_test_cases.py
@@ -52,7 +52,7 @@ PARSER_TEST_CASES = dict(
         }""",
         expected=dict(
             expired="yes",
-            event_id={"type": "none", "id": 0, "random": [0, 3991148998]},
+            scope={"type": "none", "id": 0, "random": [0, 3991148998]},
         ),
     ),
     update_espionage_manager=dict(


### PR DESCRIPTION
Gamestate keys sometimes do not have values, eg `key1= key2=value`
We had some handling for this already, but instead of interpreting the above as
```js
{ key1: null, key2: "value" }
```
we interpreted it as
```js
{ key1: "value" }
```
Besides being incorrect, this also failed completely if a valueless key was the last in an object, eg `key1=value key2=`, as is the case in the saved attached to #187 