### PR TITLE
Fix timelapse frame export (#98)

### DIFF
--- a/stellarisdashboard/dashboard_app/graph_ledger.py
+++ b/stellarisdashboard/dashboard_app/graph_ledger.py
@@ -289,6 +289,7 @@ def trigger_timeline_export(
             end_date = datamodel.days_to_date(utils.get_most_recent_date(session))
     step_days = step_days or TIMELAPSE_DEFAULT_STEP
     frame_time_ms = frame_time_ms or TIMELAPSE_DEFAULT_FRAME_TIME
+    dpi = dpi or TIMELAPSE_DEFAULT_DPI
 
     export_gif = "export_gif" in export_mode
     export_webp = "export_webp" in export_mode


### PR DESCRIPTION
- Added check for `dpi` parameter to handle case where it was set to `None`

Details copied from #98:

It appears that the dpi parameter for `graph_ledger:trigger_timeline_export(...)` was not being checked for `None` in the case where the user did not interact with the html input control for DPI.