### PR TITLE
perf(read-path): eager-load country data and memoize name rendering

### DIFF
--- a/stellarisdashboard/datamodel.py
+++ b/stellarisdashboard/datamodel.py
@@ -400,8 +400,7 @@ def get_gamestates_since(game_name: str, date: float):
             session.query(GameState)
             .filter(GameState.game == game, GameState.date > date)
             .order_by(GameState.date)
-            # Eager-load the per-country data touched by every plot container,
-            # avoiding an N+1 lazy SELECT per country per gamestate on the read path.
+            # eager-load to avoid an N+1 lazy SELECT per country per gamestate
             .options(
                 selectinload(GameState.country_data).selectinload(CountryData.country)
             )

--- a/stellarisdashboard/datamodel.py
+++ b/stellarisdashboard/datamodel.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Union, Optional, Iterable, Collection
 import sqlalchemy
 from sqlalchemy import Column, Integer, String, ForeignKey, Float, Boolean, Enum
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship, scoped_session
+from sqlalchemy.orm import sessionmaker, relationship, scoped_session, selectinload
 
 from alembic.autogenerate import produce_migrations
 from alembic.migration import MigrationContext
@@ -400,6 +400,11 @@ def get_gamestates_since(game_name: str, date: float):
             session.query(GameState)
             .filter(GameState.game == game, GameState.date > date)
             .order_by(GameState.date)
+            # Eager-load the per-country data touched by every plot container,
+            # avoiding an N+1 lazy SELECT per country per gamestate on the read path.
+            .options(
+                selectinload(GameState.country_data).selectinload(CountryData.country)
+            )
             .all()
         ):
             yield gs

--- a/stellarisdashboard/game_info.py
+++ b/stellarisdashboard/game_info.py
@@ -275,11 +275,8 @@ class NameRenderer:
 global_renderer: NameRenderer = None
 
 
-# Rendering a name is a pure function of its JSON string for a given renderer
-# (the renderer/localization is a process-wide singleton). It is called per
-# country, per gamestate, per plot container on the read path, so memoizing it
-# removes a large amount of redundant JSON parsing + template rendering.
-# The cache is cleared in get_global_renderer() whenever the renderer is rebuilt.
+# Pure function of json_str for the singleton renderer; hot on the read path.
+# Cache is cleared in get_global_renderer() when the renderer is rebuilt.
 @functools.lru_cache(maxsize=2**14)
 def render_name(json_str: str):
     return get_global_renderer().render_from_json(json_str)
@@ -296,9 +293,7 @@ def get_global_renderer() -> NameRenderer:
 
         global_renderer = NameRenderer(config.CONFIG.localization_files)
         global_renderer.load_name_mapping()
-        # New renderer (e.g. after a localization/language change) -> any names
-        # cached against the previous renderer are now stale.
-        render_name.cache_clear()
+        render_name.cache_clear()  # drop names cached against the old renderer
     return global_renderer
 
 

--- a/stellarisdashboard/game_info.py
+++ b/stellarisdashboard/game_info.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import re
@@ -274,6 +275,12 @@ class NameRenderer:
 global_renderer: NameRenderer = None
 
 
+# Rendering a name is a pure function of its JSON string for a given renderer
+# (the renderer/localization is a process-wide singleton). It is called per
+# country, per gamestate, per plot container on the read path, so memoizing it
+# removes a large amount of redundant JSON parsing + template rendering.
+# The cache is cleared in get_global_renderer() whenever the renderer is rebuilt.
+@functools.lru_cache(maxsize=2**14)
 def render_name(json_str: str):
     return get_global_renderer().render_from_json(json_str)
 
@@ -289,6 +296,9 @@ def get_global_renderer() -> NameRenderer:
 
         global_renderer = NameRenderer(config.CONFIG.localization_files)
         global_renderer.load_name_mapping()
+        # New renderer (e.g. after a localization/language change) -> any names
+        # cached against the previous renderer are now stale.
+        render_name.cache_clear()
     return global_renderer
 
 


### PR DESCRIPTION
@
## What

Tier 1 of the read-path performance work. Two low-risk, behavior-preserving changes:

- **Eager-load `CountryData -> Country`** in `get_gamestates_since` via `selectinload`. Previously every plot container independently lazy-loaded `cd.country` for each country, each gamestate (no eager loading existed anywhere), producing an N+1 SELECT storm on every dashboard read.
- **Memoize `render_name`** with a bounded `functools.lru_cache`. It is a pure function of its JSON string for the process-wide singleton renderer, but was re-parsing JSON and re-rendering the name template on every call (per country, per gamestate, per container). The cache is cleared in `get_global_renderer()` whenever the renderer is rebuilt, so a localization/language change cannot serve stale names.

## Why

The dashboard "slow to browse" cost was largely redundant work on the read path, not inherent. These are the highest-confidence items from the performance plan; loop inversion and session-scoping were intentionally deferred (the latter belongs with the Tier 2 WAL/lock work).

## Results

Cold full rebuild of all plot data over a 203-save game (median of 5 runs):

| Visibility | Traces | Before | After | Speedup |
| --- | --- | --- | --- | --- |
| default (player-met countries) | 257 | 7.65s | 3.46s | 2.2x |
| `show_everything` (all countries) | 1575 | 8.98s | 3.07s | 2.9x |

The heavier all-countries load shows the larger win, confirming the default early-game numbers understate the benefit.

## Correctness

Plot output verified **byte-identical** before vs. after (sha256 digest over all 70 plots / traces) in both visibility configs. Existing test suite shows no new failures (the 11 `names_test::test_name_rendering_with_game_files` failures are pre-existing, depend on installed Stellaris 4.1 localization files, and bypass the cache by calling `render_from_dict` directly).

## Reviewer notes

- The `selectinload` scope was checked against every per-country container and the `show_*_info()` helpers: they only read `CountryData` columns plus `cd.country` columns, so nothing is under-fetched.
- `render_name` is only ever called with `str`/`None` (String columns), both hashable, so the cache key is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@