### PR TITLE
perf(db): SQLite WAL + write-only per-game lock (concurrency)

### DIFF
--- a/stellarisdashboard/datamodel.py
+++ b/stellarisdashboard/datamodel.py
@@ -24,26 +24,14 @@ logger = logging.getLogger(__name__)
 Base = declarative_base()
 _ENGINES = {}
 _SESSIONMAKERS = {}
-# Per-game lock serializing *writers* only. With WAL (see _set_sqlite_pragmas)
-# SQLite gives readers a consistent snapshot concurrent with a single writer, so
-# readers no longer take this lock and the dashboard stays responsive during ingest.
-_DB_LOCKS = {}
-# Guards the lazy engine/sessionmaker setup below, which is no longer serialized
-# by the per-game lock now that readers skip it.
-_ENGINE_SETUP_LOCK = threading.Lock()
-
-# Busy timeout (ms) a connection waits for SQLite's write lock before erroring.
+_DB_LOCKS = {}  # per-game lock; under WAL only writers take it (see get_db_session)
+_ENGINE_SETUP_LOCK = threading.Lock()  # guards lazy engine setup below
 _SQLITE_BUSY_TIMEOUT_MS = 30_000
 
 
 def _set_sqlite_pragmas(dbapi_connection, connection_record):
-    """Apply per-connection SQLite tuning. Runs on every new pooled connection.
-
-    - WAL: readers (dashboard) don't block on the writer (parser) and vice versa.
-    - synchronous=NORMAL: far fewer fsyncs during ingest; safe under WAL for this
-      app (the DB is derived data, fully re-derivable by re-parsing saves).
-    - busy_timeout: wait rather than immediately raising "database is locked".
-    """
+    # WAL lets readers and the single writer run concurrently; synchronous=NORMAL
+    # cuts fsyncs (safe: the DB is re-derivable by re-parsing saves).
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA journal_mode=WAL")
     cursor.execute("PRAGMA synchronous=NORMAL")
@@ -54,7 +42,7 @@ def _set_sqlite_pragmas(dbapi_connection, connection_record):
 def _get_or_create_sessionmaker(game_id):
     if game_id not in _SESSIONMAKERS:
         with _ENGINE_SETUP_LOCK:
-            if game_id not in _SESSIONMAKERS:  # double-checked under the lock
+            if game_id not in _SESSIONMAKERS:  # double-checked
                 _setup_engine(game_id)
     return _SESSIONMAKERS[game_id]
 
@@ -101,12 +89,8 @@ def _setup_engine(game_id):
 
 @contextlib.contextmanager
 def get_db_session(game_id, write: bool = False) -> sqlalchemy.orm.Session:
-    """Yield a session for the given game.
-
-    :param write: writers pass ``write=True`` to serialize on the per-game lock.
-        Readers leave it ``False`` and rely on WAL for snapshot isolation, so the
-        dashboard does not block while the parser ingests a new save.
-    """
+    # write=True serializes on the per-game lock; readers rely on WAL snapshots
+    # so they don't block while the parser ingests.
     session_factory = _get_or_create_sessionmaker(game_id)
     lock = _DB_LOCKS[game_id] if write else contextlib.nullcontext()
     with lock:

--- a/stellarisdashboard/datamodel.py
+++ b/stellarisdashboard/datamodel.py
@@ -24,47 +24,92 @@ logger = logging.getLogger(__name__)
 Base = declarative_base()
 _ENGINES = {}
 _SESSIONMAKERS = {}
+# Per-game lock serializing *writers* only. With WAL (see _set_sqlite_pragmas)
+# SQLite gives readers a consistent snapshot concurrent with a single writer, so
+# readers no longer take this lock and the dashboard stays responsive during ingest.
 _DB_LOCKS = {}
+# Guards the lazy engine/sessionmaker setup below, which is no longer serialized
+# by the per-game lock now that readers skip it.
+_ENGINE_SETUP_LOCK = threading.Lock()
+
+# Busy timeout (ms) a connection waits for SQLite's write lock before erroring.
+_SQLITE_BUSY_TIMEOUT_MS = 30_000
+
+
+def _set_sqlite_pragmas(dbapi_connection, connection_record):
+    """Apply per-connection SQLite tuning. Runs on every new pooled connection.
+
+    - WAL: readers (dashboard) don't block on the writer (parser) and vice versa.
+    - synchronous=NORMAL: far fewer fsyncs during ingest; safe under WAL for this
+      app (the DB is derived data, fully re-derivable by re-parsing saves).
+    - busy_timeout: wait rather than immediately raising "database is locked".
+    """
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA synchronous=NORMAL")
+    cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+    cursor.close()
+
+
+def _get_or_create_sessionmaker(game_id):
+    if game_id not in _SESSIONMAKERS:
+        with _ENGINE_SETUP_LOCK:
+            if game_id not in _SESSIONMAKERS:  # double-checked under the lock
+                _setup_engine(game_id)
+    return _SESSIONMAKERS[game_id]
+
+
+def _setup_engine(game_id):
+    db_file = config.CONFIG.db_path / f"{game_id}.db"
+    if not db_file.exists():
+        logger.info(f"Creating database for game {game_id} in file {db_file}.")
+    engine = sqlalchemy.create_engine(
+        f"sqlite:///{db_file}",
+        echo=False,
+        connect_args={"timeout": _SQLITE_BUSY_TIMEOUT_MS / 1000},
+    )
+    sqlalchemy.event.listen(engine, "connect", _set_sqlite_pragmas)
+
+    # auto-migrate the DB
+    # based on https://alembic.sqlalchemy.org/en/latest/cookbook.html#run-alembic-operation-objects-directly-as-in-from-autogenerate
+    with engine.connect() as connection:
+        mc = MigrationContext.configure(connection)
+        migrations = produce_migrations(mc, Base.metadata)
+        operations = Operations(mc)
+        use_batch = engine.name == "sqlite"
+        stack = [migrations.upgrade_ops]
+        while stack:
+            elem = stack.pop(0)
+            if use_batch and isinstance(elem, ModifyTableOps):
+                with operations.batch_alter_table(
+                    elem.table_name, schema=elem.schema
+                ) as batch_ops:
+                    for table_elem in elem.ops:
+                        if isinstance(table_elem, CreateForeignKeyOp):
+                            # see alembic bug about constraint names: https://github.com/sqlalchemy/alembic/issues/1195
+                            table_elem.constraint_name = table_elem.local_cols[0]
+                        batch_ops.invoke(table_elem)
+            elif hasattr(elem, "ops"):
+                stack.extend(elem.ops)
+            else:
+                operations.invoke(elem)
+
+    _ENGINES[game_id] = engine
+    _SESSIONMAKERS[game_id] = scoped_session(sessionmaker(bind=engine))
+    _DB_LOCKS[game_id] = threading.Lock()
 
 
 @contextlib.contextmanager
-def get_db_session(game_id) -> sqlalchemy.orm.Session:
-    if game_id not in _SESSIONMAKERS:
-        db_file = config.CONFIG.db_path / f"{game_id}.db"
-        if not db_file.exists():
-            logger.info(f"Creating database for game {game_id} in file {db_file}.")
-        engine = sqlalchemy.create_engine(f"sqlite:///{db_file}", echo=False)
+def get_db_session(game_id, write: bool = False) -> sqlalchemy.orm.Session:
+    """Yield a session for the given game.
 
-        # auto-migrate the DB
-        # based on https://alembic.sqlalchemy.org/en/latest/cookbook.html#run-alembic-operation-objects-directly-as-in-from-autogenerate
-        with engine.connect() as connection:
-            mc = MigrationContext.configure(connection)
-            migrations = produce_migrations(mc, Base.metadata)
-            operations = Operations(mc)
-            use_batch = engine.name == "sqlite"
-            stack = [migrations.upgrade_ops]
-            while stack:
-                elem = stack.pop(0)
-                if use_batch and isinstance(elem, ModifyTableOps):
-                    with operations.batch_alter_table(
-                        elem.table_name, schema=elem.schema
-                    ) as batch_ops:
-                        for table_elem in elem.ops:
-                            if isinstance(table_elem, CreateForeignKeyOp):
-                                # see alembic bug about constraint names: https://github.com/sqlalchemy/alembic/issues/1195
-                                table_elem.constraint_name = table_elem.local_cols[0]
-                            batch_ops.invoke(table_elem)
-                elif hasattr(elem, "ops"):
-                    stack.extend(elem.ops)
-                else:
-                    operations.invoke(elem)
-
-        _ENGINES[game_id] = engine
-        _SESSIONMAKERS[game_id] = scoped_session(sessionmaker(bind=engine))
-        _DB_LOCKS[game_id] = threading.Lock()
-
-    with _DB_LOCKS[game_id]:
-        session_factory = _SESSIONMAKERS[game_id]
+    :param write: writers pass ``write=True`` to serialize on the per-game lock.
+        Readers leave it ``False`` and rely on WAL for snapshot isolation, so the
+        dashboard does not block while the parser ingests a new save.
+    """
+    session_factory = _get_or_create_sessionmaker(game_id)
+    lock = _DB_LOCKS[game_id] if write else contextlib.nullcontext()
+    with lock:
         s = session_factory()
         try:
             yield s

--- a/stellarisdashboard/parsing/timeline.py
+++ b/stellarisdashboard/parsing/timeline.py
@@ -51,7 +51,7 @@ class TimelineExtractor:
         self._read_basic_game_info(game_id)
         logger.info(f"{self.basic_info.logger_str} Processing Gamestate")
         t_start_gs = time.process_time()
-        with datamodel.get_db_session(game_id=game_id) as self._session:
+        with datamodel.get_db_session(game_id=game_id, write=True) as self._session:
             try:
                 db_game = self._get_or_add_game_to_db(game_id)
                 if self._check_if_gamestate_exists(db_game):


### PR DESCRIPTION
## What

Tier 2 (#4 + #5) of the performance plan: make the dashboard stay responsive while the parser ingests saves.

- **WAL + pragmas** (`datamodel.py`): a `connect` event listener applies `journal_mode=WAL`, `synchronous=NORMAL`, and `busy_timeout=30s` (plus `connect_args timeout`) to every connection.
- **Write-only lock** (`datamodel.py`, `timeline.py`): `get_db_session(game_id, write=False)` now only takes the per-game `threading.Lock` when `write=True`. The timeline writer passes `write=True`; all readers skip the lock and rely on WAL for snapshot isolation. Lazy engine/sessionmaker setup is guarded by a dedicated setup lock since readers no longer serialize there.

## Why

The dashboard (reader) and the save parser (writer) run in the same process on separate threads and serialized on one per-game lock held for the entire session — so every multi-second gamestate write stalled all dashboard reads, and vice versa.

## Results

Reader waiting on a writer that holds the DB for 2.0s:

| | reader wait |
| --- | --- |
| before (reads take the lock) | 2.002s |
| after (WAL + write-only lock) | **0.002s** |

Single-threaded **ingest time is essentially unchanged** (~2%) — it is CPU-bound in the SQLAlchemy unit-of-work, not fsync-bound. WAL's value here is concurrency, not raw ingest speed.

## Correctness

Plot output verified **byte-identical** before/after (sha256 digest, default and `show_everything`). A reader/writer concurrency check confirms the reader proceeds during a held write. Full test suite passes (69 passed).

## Scope note

`#6` (bulk inserts) was profiled and intentionally **not** included: the ingest cost is autoflush-driven flush overhead spread across ~5,300 get-or-create lookups per gamestate; the safe mitigation yields no measurable speedup, and the effective one (global `no_autoflush`) is incorrect because some processors query by an unflushed PK. It needs a dedicated write-path refactor and is deferred.

This is independent of #207 (read-path CPU) and touches different code, so they review/merge separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
