### PR TITLE
Automate release pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -66,3 +68,26 @@ jobs:
         with:
           name: stellarisdashboard-${{ matrix.os }}.zip
           path: stellarisdashboard-${{ matrix.os }}.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Prepare release files
+        run: |
+          mkdir release_files
+          find artifacts -name "*.zip" -exec cp {} release_files/ \;
+          ls -la release_files/
+      - name: Create Release Draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} release_files/* --draft --generate-notes
+


### PR DESCRIPTION
This PR automates the release process for Stellaris Dashboard. When a version tag starting with v (e.g., v7.1.1) is pushed, a GitHub Actions run is triggered which builds the binaries and automatically creates a draft GitHub release with the compiled zip files and auto-generated release notes attached.