### PR TITLE
fix(db): commit schema auto-migration so it persists on existing DBs

### DIFF
--- a/stellarisdashboard/datamodel.py
+++ b/stellarisdashboard/datamodel.py
@@ -81,6 +81,10 @@ def _setup_engine(game_id):
                 stack.extend(elem.ops)
             else:
                 operations.invoke(elem)
+        # Commit the migration: under SQLAlchemy 2.0 a Connection rolls back on
+        # block exit unless committed, which silently discarded the schema
+        # changes for pre-existing DBs (new columns never landed).
+        connection.commit()
 
     _ENGINES[game_id] = engine
     _SESSIONMAKERS[game_id] = scoped_session(sessionmaker(bind=engine))


### PR DESCRIPTION
## Problem
Opening an older game's history ledger 500s with:
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: leader.creator_id
```

## Root cause
`datamodel._setup_engine` runs alembic's auto-generated migration ops inside a `with engine.connect() as connection:` block, but never calls `connection.commit()`. Under **SQLAlchemy 2.0**, a `Connection` is in commit-as-you-go mode and **rolls back on block exit** unless committed — so for any DB created by an older schema, the generated `ADD COLUMN`s (`leader.creator_id`, `planet_id`, `ethic`, `job`, …) were silently discarded. A partially-applied SQLite batch could also leave an orphan `_alembic_tmp_leader` table behind that poisoned subsequent migration runs.

Fresh DBs are unaffected (metadata matches the schema, so there's nothing to migrate), which is why this only hit pre-existing saves.

## Fix
Add `connection.commit()` after the migration loop.

## Verification
Reproduced against a real pre-existing DB, then with the fix confirmed:
- the previously-missing columns now persist on disk,
- the orphan `_alembic_tmp_leader` table is cleaned up,
- `/history/<old_game>` renders the full ledger (was 500 → now 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)