### PR TITLE
Bump version to 8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stellarisdashboard"
-version = "7.1.0"
+version = "8.0.0"
 description = "Reads Stellaris save files while you play and shows detailed statistics and an event ledger for your playthrough."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/stellarisdashboard/dashboard_app/utils.py
+++ b/stellarisdashboard/dashboard_app/utils.py
@@ -7,7 +7,7 @@ from stellarisdashboard import datamodel
 
 logger = logging.getLogger(__name__)
 
-VERSION = "v7.1.0"
+VERSION = "v8.0.0"
 
 
 def parse_version(version: str):

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "stellarisdashboard"
-version = "7.1.0"
+version = "8.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Major version bump to **8.0.0** ahead of cutting a new release.

This bumps the version in the three places that track it:
- `pyproject.toml`
- `uv.lock` (editable package entry)
- `stellarisdashboard/dashboard_app/utils.py` (`VERSION`, used for the in-dashboard "old version" notice)

### Why a major bump

A lot of substantial rework has landed on `master` since `v7.1.0`:
- Migration to `uv` + `pyproject.toml`, modernized to Python 3.14 (#206)
- Rust parser hardening + crash fixes on dictionary references
- Read-path / DB performance overhaul (SQLite WAL + per-game write lock, eager-loading to kill N+1s, name-render memoization)
- Full frontend redesign (sci-fi sidebar, plot grid, galaxy map)
- Multi-phase ledger rework (theme tokens, unified app shell, htmx partial nav + in-place settings save, data-driven event descriptor registry)
- Automated draft-release creation in the GitHub Actions workflow

### Release flow

Once this merges to `master`, tagging master HEAD as `v8.0.0` triggers `.github/workflows/build.yml`: it builds the all-OS PyInstaller artifacts and the `release` job creates a draft GitHub Release with the zips attached and auto-generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PB7a82EdpLZafNcF6XQ8gG)_