### PR TITLE
Fix release job: give gh the repo via GH_REPO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Create Release Draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh needs to know the target repo; the release job has no checkout,
+          # so without this gh fails with "fatal: not a git repository".
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release create ${{ github.ref_name }} release_files/* --draft --generate-notes
 


### PR DESCRIPTION
## Problem

During the `v8.0.0` tag run, all three OS **builds passed** but the `release` job **failed**:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `release` job downloads artifacts but never checks out the repo, so `gh release create` can't resolve which repository to target.

## Fix

Set `GH_REPO: ${{ github.repository }}` in the "Create Release Draft" step's env. `gh` then targets the repo via the API without needing a local git checkout.

## Note on v8.0.0

The v8.0.0 draft release was created manually as a workaround (downloading the three already-built zips from the failed run and uploading them via `gh` from a local checkout). The artifacts are identical to what CI built. This PR ensures the **next** tag release completes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)